### PR TITLE
fixed apparent typo of "Creddit" to "Credit"

### DIFF
--- a/praw/errors.py
+++ b/praw/errors.py
@@ -438,11 +438,11 @@ class InvalidUserPass(APIException):
     ERROR_TYPE = 'WRONG_PASSWORD'
 
 
-class InsufficientCreddits(APIException):
+class InsufficientCredits(APIException):
 
-    """Raised when there are not enough creddits to complete the action."""
+    """Raised when there are not enough credits to complete the action."""
 
-    ERROR_TYPE = 'INSUFFICIENT_CREDDITS'
+    ERROR_TYPE = 'INSUFFICIENT_CREDITS'
 
 
 class NotLoggedIn(APIException):


### PR DESCRIPTION
The error used "Creddit" instead of "Credit", which appeared to be a typo in both the Documentation and error module.